### PR TITLE
setup.py should also install pyckup.syncers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ Setup declaration to install Pyckup
 params = dict(
     name='Pyckup',
     version='0.1.0',
-    packages=['pyckup'],
+    packages=['pyckup', 'pyckup.syncers'],
     url='https://github.com/BenjaminSchubert/Pyckup',
     download_url="https://github.com/BenjaminSchubert/Pyckup/tar.gz/0.1",
     license='MIT',


### PR DESCRIPTION
`setup.py` do not install the `pyckup.syncers`, which make `pyckup` fail to launch.