### PR TITLE
use relative path for "current" symlink

### DIFF
--- a/pyckup/syncers/local.py
+++ b/pyckup/syncers/local.py
@@ -29,5 +29,5 @@ class LocalSyncer(AbstractSyncer):
             os.path.join(self.destination, self.start_date)
         )
 
-        os.symlink(os.path.join(self.destination, self.start_date), os.path.join(self.destination, "next-current"))
+        os.symlink(os.path.relpath(self.start_date), os.path.join(self.destination, "next-current"))
         os.rename(os.path.join(self.destination, "next-current"), os.path.join(self.destination, "current"))


### PR DESCRIPTION
The "current" symlink is absolute, which, if the destination is mounted elsewhere, would be a small trouble. By having it relative, we have a more contained backup.